### PR TITLE
Fix OSX build

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,6 +7,7 @@ if [ $(uname) == Darwin ]; then
   export CXX=clang++
   export MACOSX_DEPLOYMENT_TARGET="10.9"
   export CXXFLAGS="-stdlib=libc++ $CXXFLAGS"
+  export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
 fi
 
 # CircleCI seems to have some weird issue with harfbuzz tarballs. The files


### PR DESCRIPTION
I don't see how the previous commits could have broken linking on OSX, and they were CI'd before the new gobject-introspection was distributed, I think. But so be it. I think this change will fix OSX.