### PR TITLE
Fix Windows pkg-config files

### DIFF
--- a/recipe/0002-Generate-.pc-files-when-using-the-CMake-build-system.patch
+++ b/recipe/0002-Generate-.pc-files-when-using-the-CMake-build-system.patch
@@ -11,10 +11,10 @@ need updating.
  2 files changed, 31 insertions(+), 1 deletion(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1e7282f..ae99556 100644
+index f64f96d..5ef4915 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -282,6 +282,7 @@ if (HB_HAVE_FREETYPE)
+@@ -265,6 +265,7 @@ if (HB_HAVE_FREETYPE)
      message(FATAL_ERROR "HB_HAVE_FREETYPE was set, but we failed to find it. Maybe add a CMAKE_PREFIX_PATH= to your Freetype2 install prefix")
    endif ()
  
@@ -22,7 +22,7 @@ index 1e7282f..ae99556 100644
    list(APPEND THIRD_PARTY_LIBS ${FREETYPE_LIBRARIES})
    include_directories(AFTER ${FREETYPE_INCLUDE_DIRS})
    add_definitions(-DHAVE_FREETYPE=1)
-@@ -301,6 +302,7 @@ if (HB_HAVE_GRAPHITE2)
+@@ -284,6 +285,7 @@ if (HB_HAVE_GRAPHITE2)
  
    find_path(GRAPHITE2_INCLUDE_DIR graphite2/Font.h)
    find_library(GRAPHITE2_LIBRARY graphite2)
@@ -30,7 +30,7 @@ index 1e7282f..ae99556 100644
  
    include_directories(${GRAPHITE2_INCLUDE_DIR})
  
-@@ -326,6 +328,7 @@ if (HB_HAVE_GLIB)
+@@ -309,6 +311,7 @@ if (HB_HAVE_GLIB)
    # https://github.com/WebKit/webkit/blob/master/Source/cmake/FindGLIB.cmake
    find_package(PkgConfig)
    pkg_check_modules(PC_GLIB QUIET glib-2.0)
@@ -38,7 +38,7 @@ index 1e7282f..ae99556 100644
  
    find_library(GLIB_LIBRARIES NAMES glib-2.0 HINTS ${PC_GLIB_LIBDIR} ${PC_GLIB_LIBRARY_DIRS})
    find_path(GLIBCONFIG_INCLUDE_DIR NAMES glibconfig.h HINTS ${PC_LIBDIR} ${PC_LIBRARY_DIRS} ${PC_GLIB_INCLUDEDIR} ${PC_GLIB_INCLUDE_DIRS} PATH_SUFFIXES glib-2.0/include)
-@@ -390,6 +393,7 @@ if (APPLE AND HB_HAVE_CORETEXT)
+@@ -373,6 +376,7 @@ if (APPLE AND HB_HAVE_CORETEXT)
      find_library(APPLICATION_SERVICES_FRAMEWORK ApplicationServices)
      if (APPLICATION_SERVICES_FRAMEWORK)
        list(APPEND THIRD_PARTY_LIBS ${APPLICATION_SERVICES_FRAMEWORK})
@@ -46,7 +46,7 @@ index 1e7282f..ae99556 100644
      endif ()
  
      mark_as_advanced(APPLICATION_SERVICES_FRAMEWORK)
-@@ -403,6 +407,7 @@ if (WIN32 AND HB_HAVE_UNISCRIBE)
+@@ -386,6 +390,7 @@ if (WIN32 AND HB_HAVE_UNISCRIBE)
    list(APPEND project_headers ${PROJECT_SOURCE_DIR}/src/hb-uniscribe.h)
  
    list(APPEND THIRD_PARTY_LIBS usp10 gdi32 rpcrt4)
@@ -54,7 +54,7 @@ index 1e7282f..ae99556 100644
  endif ()
  
  if (WIN32 AND HB_HAVE_DIRECTWRITE)
-@@ -412,6 +417,7 @@ if (WIN32 AND HB_HAVE_DIRECTWRITE)
+@@ -395,6 +400,7 @@ if (WIN32 AND HB_HAVE_DIRECTWRITE)
    list(APPEND project_headers ${PROJECT_SOURCE_DIR}/src/hb-directwrite.h)
  
    list(APPEND THIRD_PARTY_LIBS dwrite rpcrt4)
@@ -62,7 +62,7 @@ index 1e7282f..ae99556 100644
  endif ()
  
  if (HB_HAVE_GOBJECT)
-@@ -860,6 +866,30 @@ if (UNIX AND CMAKE_GENERATOR STREQUAL "Ninja")
+@@ -842,6 +848,30 @@ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
    endif ()
  endif ()
  
@@ -90,9 +90,9 @@ index 1e7282f..ae99556 100644
 +  endforeach ()
 +endif()
 +
- 
- if (NOT HB_DISABLE_TESTS)
+ if (HB_BUILD_TESTS)
    ## src/ executables
+   foreach (prog main test test-would-substitute test-size-params test-buffer-serialize hb-ot-tag test-unicode-ranges)
 diff --git a/src/harfbuzz-icu.pc.in b/src/harfbuzz-icu.pc.in
 index 949869a..3332a65 100644
 --- a/src/harfbuzz-icu.pc.in

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - 0002-Generate-.pc-files-when-using-the-CMake-build-system.patch  # [win]
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
They were missing from the most recent builds since the patch would still apply, but with offsets that broke its behavior.

* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
