### PR TITLE
Add glib to run deps

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -4,6 +4,8 @@ c_compiler_version:
 - '7'
 cairo:
 - '1.16'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -4,6 +4,8 @@ c_compiler_version:
 - '8'
 cairo:
 - '1.16'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # pretty excellent forward compatibility
     # https://abi-laboratory.pro/index.php?view=timeline&l=harfbuzz
@@ -34,6 +34,7 @@ requirements:
     - graphite2
   run:
     - cairo
+    - glib
     - freetype
     - icu
     - graphite2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - graphite2
   run:
     - cairo
-    - glib
+    - libglib
     - freetype
     - icu
     - graphite2


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
As indicated in the pkg-config file, glib is required when running harfbuzz and should thus be listed in the run dependencies.
```
Requires.private: freetype2, graphite2, glib-2.0
```
I found this bug when trying to compile opencv on aarch, where:

```
-- Checking for module 'harfbuzz'
--   Package 'glib-2.0', required by 'harfbuzz', not found
```

When pulling in glib manually, harfbuzz is found correctly.